### PR TITLE
Don't create service as nested stack

### DIFF
--- a/ecs-refarch-continuous-deployment.yaml
+++ b/ecs-refarch-continuous-deployment.yaml
@@ -67,8 +67,6 @@ Resources:
         GitHubRepo: !Ref GitHubRepo
         GitHubBranch: !Ref GitHubBranch
         TargetGroup: !GetAtt LoadBalancer.Outputs.TargetGroup
-        Repository: !GetAtt Service.Outputs.Repository
-        StackName: !GetAtt Service.Outputs.StackName
         TemplateBucket: ecs-refarch-continuous-deployment
 
   LoadBalancer:
@@ -78,14 +76,6 @@ Resources:
       Parameters:
         Subnets: !GetAtt VPC.Outputs.Subnets
         VpcId: !GetAtt VPC.Outputs.VpcId
-
-  Service:
-    Type: AWS::CloudFormation::Stack
-    Properties:
-      TemplateURL: https://s3.amazonaws.com/ecs-refarch-continuous-deployment/templates/service.yaml
-      Parameters:
-        Cluster: !GetAtt Cluster.Outputs.ClusterName
-        TargetGroup: !GetAtt LoadBalancer.Outputs.TargetGroup
 
   VPC:
     Type: AWS::CloudFormation::Stack

--- a/templates/deployment-pipeline.yaml
+++ b/templates/deployment-pipeline.yaml
@@ -14,12 +14,6 @@ Parameters:
   TargetGroup:
     Type: String
 
-  StackName:
-    Type: String
-
-  Repository:
-    Type: String
-
   Cluster:
     Type: String
 
@@ -28,6 +22,10 @@ Parameters:
 
 
 Resources:
+  Repository:
+    Type: AWS::ECR::Repository
+    DeletionPolicy: Retain
+
   CloudFormationExecutionRole:
     Type: AWS::IAM::Role
     DeletionPolicy: Retain
@@ -237,7 +235,7 @@ Resources:
               Configuration:
                 ChangeSetName: Deploy
                 ActionMode: CREATE_UPDATE
-                StackName: !Ref StackName
+                StackName: !Sub "${AWS::StackName}-Service"
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: Template::templates/service.yaml
                 RoleArn: !GetAtt CloudFormationExecutionRole.Arn
@@ -246,7 +244,8 @@ Resources:
                     "Tag" : { "Fn::GetParam" : [ "BuildOutput", "build.json", "tag" ] },
                     "DesiredCount": "1",
                     "Cluster": "${Cluster}",
-                    "TargetGroup": "${TargetGroup}"
+                    "TargetGroup": "${TargetGroup}",
+                    "Repository": "${Repository}"
                   }
               InputArtifacts:
                 - Name: Template

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -13,6 +13,9 @@ Parameters:
   Cluster:
     Type: String
 
+  Repository:
+    Type: String
+
 
 Resources:
   ECSServiceRole:
@@ -30,10 +33,6 @@ Resources:
         }
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole
-
-  Repository:
-    Type: AWS::ECR::Repository
-    DeletionPolicy: Retain
 
   Service:
     Type: AWS::ECS::Service
@@ -81,11 +80,3 @@ Resources:
             - /bin/sh -c "while true; do /bin/date > /var/www/my-vol/date; sleep 1; done"
       Volumes:
         - Name: my-vol
-
-
-Outputs:
-  Repository:
-    Value: !Ref Repository
-
-  StackName:
-    Value: !Ref AWS::StackName


### PR DESCRIPTION
Instead of creating the service as a nested stack, let AWS CodePipeline
create these resources during its initial execution. This decouples the
service stack from the rest of the stacks which has the benefit of
ensuring they can be independently updated. Previously, the pipeline
would update the nested stack directly which could lead to cases where
the parent and nested stacks become out of sync and could cause the
parent to get wedged into a UPDATE_ROLLBACK_FAILED stack.

See https://github.com/awslabs/ecs-refarch-continuous-deployment/issues/3 for more details.