### PR TITLE
Don't fail if user chooses long stack name

### DIFF
--- a/templates/deployment-pipeline.yaml
+++ b/templates/deployment-pipeline.yaml
@@ -30,7 +30,6 @@ Resources:
     Type: AWS::IAM::Role
     DeletionPolicy: Retain
     Properties:
-      RoleName: !Sub cfn-${AWS::StackName}
       Path: /
       AssumeRolePolicyDocument: |
         {
@@ -55,7 +54,6 @@ Resources:
   CodeBuildServiceRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub cb-${AWS::StackName}
       Path: /
       AssumeRolePolicyDocument: |
         {
@@ -97,7 +95,6 @@ Resources:
   CodePipelineServiceRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub cp-${AWS::StackName}
       Path: /
       AssumeRolePolicyDocument: |
         {

--- a/templates/ecs-cluster.yaml
+++ b/templates/ecs-cluster.yaml
@@ -48,7 +48,6 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       Path: /
-      RoleName: !Sub ecs-${AWS::StackName}
       AssumeRolePolicyDocument: |
         {
             "Statement": [{

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -21,7 +21,6 @@ Resources:
   ECSServiceRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ecs-service-${AWS::StackName}
       Path: /
       AssumeRolePolicyDocument: |
         {


### PR DESCRIPTION
IAM role names can only be 64 characters. Previously, we were
explicitly setting the role name to <Prefix>-<AWS::StackName> which
could be longer than 64 characters if a user chooses a long stack name.

This changes lets CloudFormation choose the physical names for the
roles created rather than explicitly naming them.

Resolves https://github.com/awslabs/ecs-refarch-continuous-deployment/issues/7.