### PR TITLE
Updated AMIs with newest ones

### DIFF
--- a/templates/ecs-cluster.yaml
+++ b/templates/ecs-cluster.yaml
@@ -20,27 +20,27 @@ Parameters:
 Mappings:
   AWSRegionToAMI:
     us-east-2:
-      AMI: ami-1c002379
+      AMI: ami-58f5db3d
     us-east-1:
-      AMI: ami-9eb4b1e5
+      AMI: ami-fad25980
     us-west-2:
-      AMI: ami-1d668865
+      AMI: ami-7114c909
     us-west-1:
-      AMI: ami-4a2c192a
+      AMI: ami-62e0d802
     eu-west-2:
-      AMI: ami-cb1101af
+      AMI: ami-dbfee1bf
     eu-west-1:
-      AMI: ami-8fcc32f6
+      AMI: ami-4cbe0935
     eu-central-1:
-      AMI: ami-0460cb6b
+      AMI: ami-05991b6a
     ap-northeast-1:
-      AMI: ami-b743bed1
+      AMI: ami-56bd0030
     ap-southeast-2:
-      AMI: ami-c1a6bda2
+      AMI: ami-14b55f76
     ap-southeast-1:
-      AMI: ami-9d1f7efe
+      AMI: ami-1bdc8b78
     ca-central-1:
-      AMI: ami-b677c9d2
+      AMI: ami-918b30f5
 
 Resources:
   ECSRole:


### PR DESCRIPTION
That avoids the "Outdated ECS Agent" after using/deploying this stack.