### PR TITLE
Added the missing EcsServiceRole. 

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -34,6 +34,19 @@ Conditions:
 
 
 Resources:
+  EcsServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: ecs.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole
+
   TaskExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -71,6 +84,7 @@ Resources:
         - ContainerName: simple-app
           ContainerPort: 80
           TargetGroupArn: !Ref TargetGroup
+      Role: !Ref EcsServiceRole
 
   EC2Service:
     Type: AWS::ECS::Service
@@ -84,6 +98,7 @@ Resources:
         - ContainerName: simple-app
           ContainerPort: 80
           TargetGroupArn: !Ref TargetGroup
+      Role: !Ref EcsServiceRole
 
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition


### PR DESCRIPTION
## Issue
When I am using the "service.yaml" to create EC2Service, the creation process fails at EC2Service with the following error: 

```bash
Unable to assume the service linked role. Please verify that the ECS service linked role exists.
```

## Solution
According to the following reference: 
[https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html#cfn-ecs-service-role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html#cfn-ecs-service-role)

It seems that we have to specify `Role` with `LoadBalancers` property. 

```bash
Role
...
Required: Conditional. Required only if you specify the LoadBalancers property.
...
```

So I added the missing role `EcsServiceRole` to the template file. I have tested it and it works fine. 

Cheers
Hengfeng